### PR TITLE
Added SqlBulkCopy.RowsCopied property to docs

### DIFF
--- a/xml/System.Data.SqlClient/SqlBulkCopy.xml
+++ b/xml/System.Data.SqlClient/SqlBulkCopy.xml
@@ -708,6 +708,50 @@
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>
     </Member>
+    <Member MemberName="RowsCopied">
+      <MemberSignature Language="C#" Value="public int RowsCopied { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 RowsCopied" />
+      <MemberSignature Language="DocId" Value="P:System.Data.SqlClient.SqlBulkCopy.RowsCopied" />
+      <MemberSignature Language="VB.NET" Value="Public ReadOnly Property RowsCopied As Integer" />
+      <MemberSignature Language="C++ CLI" Value="public:&#xA; property int RowsCopied { int get(); };" />
+      <MemberSignature Language="F#" Value="member this.RowsCopied : int" Usage="System.Data.SqlClient.SqlBulkCopy.RowsCopied" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>System.Data.SqlClient</AssemblyName>
+        <AssemblyVersion>4.6.0.0</AssemblyVersion>
+        <AssemblyVersion>4.6.1.0</AssemblyVersion>
+        <AssemblyVersion>4.6.1.1</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>System.Data</AssemblyName>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.5.0</AssemblyVersion>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>netstandard</AssemblyName>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Returns the number of rows processed in the ongoing bulk copy operation.</summary>
+        <value>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopy.RowsCopied" /> property, by default zero.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This value is incremented during the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event and does not imply that this number of rows has been sent to the server or committed.
+  
+ During the execution of a bulk copy operation, this value can be accessed, but it cannot be changed. Any attempt to change it will throw an <xref:System.InvalidOperationException>.
+  
+ ]]></format>
+        </remarks>
+        <related type="Article" href="/dotnet/framework/data/adonet/sql/bulk-copy-operations-in-sql-server">Bulk Copy Operations in SQL Server</related>
+        <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
+      </Docs>
+    </Member>
     <Member MemberName="SqlRowsCopied">
       <MemberSignature Language="C#" Value="public event System.Data.SqlClient.SqlRowsCopiedEventHandler SqlRowsCopied;" />
       <MemberSignature Language="ILAsm" Value=".event class System.Data.SqlClient.SqlRowsCopiedEventHandler SqlRowsCopied" />


### PR DESCRIPTION
## Summary

Added the `RowsCopied` property to docs for SqlBulkCopy, which was added in System.Data.SqlClient 2.0.0.

See https://github.com/dotnet/SqlClient/pull/409 



